### PR TITLE
Remove _RequestGlobals #2656

### DIFF
--- a/nereid/ctx.py
+++ b/nereid/ctx.py
@@ -1,7 +1,6 @@
 #This file is part of Tryton & Nereid. The COPYRIGHT file at the top level of
 #this repository contains the full copyright notices and license terms.
-from flask.ctx import (_RequestGlobals, RequestContext as  # noqa
-    RequestContextBase)
+from flask.ctx import RequestContext as RequestContextBase
 from flask.ctx import has_request_context  # noqa
 
 


### PR DESCRIPTION
Current patch imports _RequestGlobals from flask ctx which no more
exists now. So _RequestGlobals import has been removed

Review ID: 440001
