### PR TITLE
Add documentation link

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,9 +19,9 @@
         <p>Nereid - A web framework for tryton</p>
         <p class="view"><a href="https://github.com/openlabs/nereid">View the Project on GitHub <small>openlabs/nereid</small></a></p>
         <ul>
+          <li><a href="http://nereid.readthedocs.org/en/develop/">Read <strong>Docs</strong></a></li>
           <li><a href="https://github.com/openlabs/nereid/zipball/master">Download <strong>ZIP File</strong></a></li>
           <li><a href="https://github.com/openlabs/nereid/tarball/master">Download <strong>TAR Ball</strong></a></li>
-          <li><a href="https://github.com/openlabs/nereid">View On <strong>GitHub</strong></a></li>
         </ul>
       </header>
       <section>


### PR DESCRIPTION
I've added link to Read The Docs documentation. The download button links to master packages, however since the master will fail on RTD - I've linked develop docs.
