### PR TITLE
Remove SiteNamePrefix Loader #2853

### DIFF
--- a/nereid/application.py
+++ b/nereid/application.py
@@ -508,7 +508,6 @@ class Nereid(Flask):
         """
         return ModuleTemplateLoader(
             self.database_name, searchpath=self.template_folder,
-            prefix_website_name=self.template_prefix_website_name
         )
 
     def select_jinja_autoescape(self, filename):


### PR DESCRIPTION
The template loader design with SiteNamePrefix loader works once the
name of the template is passed and not for dynamically changing the
name. This is because jinja caching (environment _load_template) uses
the name to cache the content and the second time the template is loaded
the name would not have the site prefix.
