### PR TITLE
Allow headers+status to be edited on lazy renderer

### DIFF
--- a/nereid/application.py
+++ b/nereid/application.py
@@ -397,7 +397,9 @@ class Nereid(Flask):
                 result = meth(i, **req.view_args)
 
             if isinstance(result, LazyRenderer):
-                result = unicode(result)
+                result = (
+                    unicode(result), result.status, result.headers
+                )
 
             return result
 

--- a/nereid/templating.py
+++ b/nereid/templating.py
@@ -44,6 +44,11 @@ class LazyRenderer(_LazyString):
 
     >>> unicode(lazy_render_object)
 
+    The status code or header can also be set on the lazy renderer
+
+    >>> lazy_render_object.sattus = 201
+    >>> lazy_render_object.headers['X-Some-Header'] = 'header value'
+
     .. note::
 
         If the template renders objects which depend on the application,
@@ -51,9 +56,9 @@ class LazyRenderer(_LazyString):
         the call must be made within those contexts.
     """
 
-    __slots__ = ('template_name_or_list', 'context',)
+    __slots__ = ('template_name_or_list', 'context', 'headers', 'status')
 
-    def __init__(self, template_name_or_list, context):
+    def __init__(self, template_name_or_list, context, headers=None):
         """
         :param template_name_or_list: the name of the template to be
                                       rendered, or an iterable with template
@@ -64,6 +69,8 @@ class LazyRenderer(_LazyString):
         """
         self.template_name_or_list = template_name_or_list
         self.context = context
+        self.headers = {}
+        self.status = 200
 
     @property
     def value(self):
@@ -75,10 +82,16 @@ class LazyRenderer(_LazyString):
         )
 
     def __getstate__(self):
-        return self.template_name_or_list, self.context
+        return (
+            self.template_name_or_list,
+            self.context,
+            self.headers,
+            self.status,
+        )
 
     def __setstate__(self, tup):
-        self.template_name_or_list, self.context = tup
+        self.template_name_or_list, self.context, \
+                self.headers, self.status = tup
 
 
 def render_template(template_name_or_list, **context):

--- a/nereid/tests/test_templates.py
+++ b/nereid/tests/test_templates.py
@@ -305,6 +305,20 @@ class TestLazyRendering(BaseTestCase):
                 response = c.get('/registration')
                 self.assertEqual(response.status_code, 200)
 
+    def test_0040_headers(self):
+        '''
+        Change registrations headers and check
+        '''
+        trytond.tests.test_tryton.install_module('nereid_test')
+        with Transaction().start(DB_NAME, USER, CONTEXT):
+            self.setup_defaults()
+            app = self.get_app()
+
+            with app.test_client() as c:
+                response = c.get('/test-lazy-renderer')
+                self.assertEqual(response.headers['X-Test-Header'], 'TestValue')
+                self.assertEqual(response.status_code, 201)
+
 
 def suite():
     "Nereid Template Loading test suite"

--- a/setup.py
+++ b/setup.py
@@ -176,7 +176,7 @@ setup(
     test_suite='tests.suite',
     test_loader='trytond.test_loader:Loader',
     tests_require=[
-        'trytond_nereid_test >= 3.0.3.0, < 3.1',
+        'trytond_nereid_test >= 3.0.4.0, < 3.1',
         'mock',
         'pycountry',
     ],


### PR DESCRIPTION
- Adds a test case to check header and status
- Depends on 3.0.4.0 version of nereid test suite
