### PR TITLE
Fix in load_user #4102

### DIFF
--- a/trytond_nereid/party.py
+++ b/trytond_nereid/party.py
@@ -872,7 +872,13 @@ class NereidUser(ModelSQL, ModelView):
                 user, = cls.search([('id', '=', int(user_id))])
         except ValueError:
             return None
-        return user
+
+        # Instead of returning the active record returned in the above search
+        # we are creating a new record here. This is because the returned
+        # active record seems to carry around the context setting of
+        # active_test and any nested lookup from the record will result in
+        # records being fetched which are inactive.
+        return cls(int(user_id))
 
     @classmethod
     def load_user_from_header(cls, header_val):


### PR DESCRIPTION
Instead of returning the active record return a new user record. This is because the
returned active record seems to carry around the context setting of
active_test and any nested lookup from the record will result
in records being fetched which are inactive.
