### PR TITLE
Fixed default_default_locale method

### DIFF
--- a/trytond_nereid/website.py
+++ b/trytond_nereid/website.py
@@ -122,7 +122,8 @@ class WebSite(ModelSQL, ModelView):
     def default_default_locale():
         ModelData = Pool().get('ir.model.data')
 
-        return ModelData.get_id("nereid", "website_locale_en-us")
+        if not Pool().test:
+            return ModelData.get_id("nereid", "website_locale_en-us")
 
     @staticmethod
     def default_application_user():


### PR DESCRIPTION
As locale will not be created from XML in tests, so default_locale
should not depend on XML record in tests.
