### PR TITLE
If record doesn't exist corresponding to active_id. abort(404) #4780

### DIFF
--- a/trytond_nereid/tests/test_routing.py
+++ b/trytond_nereid/tests/test_routing.py
@@ -198,6 +198,27 @@ class TestRouting(NereidTestCase):
                 response = c.get('/')
                 self.assertEqual(response.data, 'es_ES')
 
+    def test_0050_invalid_active_id_url(self):
+        """
+        Test that the url if 404 if record for active_id doesn't exist
+        """
+        with Transaction().start(DB_NAME, USER, CONTEXT):
+            self.setup_defaults()
+            self.nereid_website.locales = []
+            self.nereid_website.save()
+            app = self.get_app()
+            country, = self.country_obj.create([{
+                'name': 'India',
+                'code': 'IN'
+            }])
+
+            with app.test_client() as c:
+                response = c.get('/countries/%d/subdivisions' % country.id)
+                self.assertEqual(response.status_code, 200)
+
+                response = c.get('/countries/6/subdivisions')  # Invalid record
+                self.assertEqual(response.status_code, 404)
+
 
 def suite():
     "Nereid test suite"


### PR DESCRIPTION
If record doesn't exist corresponding to active_id, then logically url
is invalid and hence url should be aborted(404) at dispatcher level
only.

Github Issue: #204
