### PR TITLE
If record doesn't exist corresponding to active_id. abort(404) #4780

### DIFF
--- a/nereid/application.py
+++ b/nereid/application.py
@@ -9,10 +9,10 @@ import inspect
 
 from flask import Flask
 from flask.config import ConfigAttribute
-from flask.globals import _request_ctx_stack
+from flask.globals import _request_ctx_stack, current_app
 from flask.helpers import locked_cached_property
 from jinja2 import MemcachedBytecodeCache
-from werkzeug import import_string
+from werkzeug import import_string, abort
 from flask_wtf.csrf import CsrfProtect
 import flask.ext.login
 from flask.ext.login import LoginManager
@@ -21,6 +21,7 @@ from trytond import backend
 from trytond.pool import Pool
 from trytond.cache import Cache
 from trytond.config import CONFIG
+from trytond.exceptions import UserError
 from trytond.modules import register_classes
 from trytond.transaction import Transaction
 
@@ -461,6 +462,15 @@ class Nereid(Flask):
                 # arguments and pass the model instance as first argument
                 model = Pool().get(req.url_rule.endpoint.rsplit('.', 1)[0])
                 i = model(req.view_args.pop('active_id'))
+                try:
+                    i.rec_name
+                except UserError:
+                    # The record may not exist anymore which results in
+                    # a read error
+                    current_app.logger.debug(
+                        "Record %s doesn't exist anymore." % i
+                    )
+                    abort(404)
                 result = meth(i, **req.view_args)
 
             if isinstance(result, LazyRenderer):

--- a/trytond_nereid/tests/test_routing.py
+++ b/trytond_nereid/tests/test_routing.py
@@ -218,6 +218,27 @@ class TestRouting(NereidTestCase):
                     WebsiteNotFound, c.get, 'http://this_should_break/'
                 )
 
+    def test_0060_invalid_active_id_url(self):
+        """
+        Test that the url if 404 if record for active_id doesn't exist
+        """
+        with Transaction().start(DB_NAME, USER, CONTEXT):
+            self.setup_defaults()
+            self.nereid_website.locales = []
+            self.nereid_website.save()
+            app = self.get_app()
+            country, = self.country_obj.create([{
+                'name': 'India',
+                'code': 'IN'
+            }])
+
+            with app.test_client() as c:
+                response = c.get('/countries/%d/subdivisions' % country.id)
+                self.assertEqual(response.status_code, 200)
+
+                response = c.get('/countries/6/subdivisions')  # Invalid record
+                self.assertEqual(response.status_code, 404)
+
 
 def suite():
     "Nereid test suite"


### PR DESCRIPTION
If record doesn't exist corresponding to active_id, then logically url
is invalid and hence url should be aborted(404) at dispatcher level
only.

Github Issue: #204
