### PR TITLE
Changed Required to DataRequired #7126

### DIFF
--- a/nereid/caching.py
+++ b/nereid/caching.py
@@ -4,6 +4,7 @@ from functools import wraps
 from hashlib import md5
 import inspect
 from warnings import warn
+
 from flask.globals import current_app
 
 warn(DeprecationWarning("This API will be deprecated"))

--- a/setup.py
+++ b/setup.py
@@ -181,13 +181,13 @@ setup(
         'trytond.modules.nereid_test': 'nereid_test_module',
     },
     package_data={
-        'trytond.modules.nereid': info.get('xml', [])
-            + ['tryton.cfg', 'view/*.xml', 'locale/*.po', 'tests/*.rst']
-            + ['i18n/*.pot', 'i18n/pt_BR/LC_MESSAGES/*']
-            + ['templates/*.*', 'templates/tests/*.*'],
-        'trytond.modules.nereid_test': ['*.xml']
-            + ['tryton.cfg', 'locale/*.po', 'tests/*.rst']
-            + ['templates/*.*', 'templates/tests/*.*'],
+        'trytond.modules.nereid': info.get('xml', []) +
+            ['tryton.cfg', 'view/*.xml', 'locale/*.po', 'tests/*.rst'] +
+            ['i18n/*.pot', 'i18n/pt_BR/LC_MESSAGES/*'] +
+            ['templates/*.*', 'templates/tests/*.*'],
+        'trytond.modules.nereid_test': ['*.xml'] +
+            ['tryton.cfg', 'locale/*.po', 'tests/*.rst'] +
+            ['templates/*.*', 'templates/tests/*.*'],
     },
     zip_safe=False,
     platforms='any',

--- a/trytond_nereid/party.py
+++ b/trytond_nereid/party.py
@@ -28,7 +28,7 @@ class AddressForm(Form):
     streetbis = TextField(_('Street (Bis)'))
     zip = TextField(_('Post Code'), [validators.DataRequired(), ])
     city = TextField(_('City'), [validators.DataRequired(), ])
-    country = SelectField(_('Country'), [validators.DataRequired(), ], coerce=int)
+    country = SelectField(_('Country'), [validators.DataRequired(), ], coerce=int)  # noqa
     subdivision = IntegerField(_('State/County'), [validators.DataRequired()])
     email = TextField(_('Email'))
     phone = TextField(_('Phone'))

--- a/trytond_nereid/party.py
+++ b/trytond_nereid/party.py
@@ -23,13 +23,13 @@ class AddressForm(Form):
     """
     A form resembling the party.address
     """
-    name = TextField(_('Name'), [validators.Required(), ])
-    street = TextField(_('Street'), [validators.Required(), ])
+    name = TextField(_('Name'), [validators.DataRequired(), ])
+    street = TextField(_('Street'), [validators.DataRequired(), ])
     streetbis = TextField(_('Street (Bis)'))
-    zip = TextField(_('Post Code'), [validators.Required(), ])
-    city = TextField(_('City'), [validators.Required(), ])
-    country = SelectField(_('Country'), [validators.Required(), ], coerce=int)
-    subdivision = IntegerField(_('State/County'), [validators.Required()])
+    zip = TextField(_('Post Code'), [validators.DataRequired(), ])
+    city = TextField(_('City'), [validators.DataRequired(), ])
+    country = SelectField(_('Country'), [validators.DataRequired(), ], coerce=int)
+    subdivision = IntegerField(_('State/County'), [validators.DataRequired()])
     email = TextField(_('Email'))
     phone = TextField(_('Phone'))
 
@@ -289,8 +289,8 @@ class Party(ModelSQL, ModelView):
 
 
 class ContactMechanismForm(Form):
-    type = SelectField('Type', [validators.Required()])
-    value = TextField('Value', [validators.Required()])
+    type = SelectField('Type', [validators.DataRequired()])
+    value = TextField('Value', [validators.DataRequired()])
     comment = TextField('Comment')
 
 

--- a/trytond_nereid/translation.py
+++ b/trytond_nereid/translation.py
@@ -164,8 +164,8 @@ class Translation:
                     continue
 
                 model = translation.name.split(',')[0]
-                if (model in fs_id2prop
-                        and res_id in fs_id2prop[model]):
+                if (model in fs_id2prop and
+                        res_id in fs_id2prop[model]):
                     res_id, noupdate = fs_id2prop[model][res_id]
 
                 if res_id:
@@ -193,8 +193,8 @@ class Translation:
                     to_write = []
                     for translation_id in ids:
                         old_translation = id2translation[translation_id]
-                        if (old_translation.value != translation.value
-                                or old_translation.fuzzy !=
+                        if (old_translation.value != translation.value or
+                                old_translation.fuzzy !=
                                 translation.fuzzy):
                             to_write.append(old_translation)
                     with Transaction().set_user(0), \
@@ -253,8 +253,8 @@ class Translation:
                 ('module', '=', module),
             ], order=[])
         for translation in translations:
-            if (translation.overriding_module
-                    and translation.overriding_module != module):
+            if (translation.overriding_module and
+                    translation.overriding_module != module):
                 cls.raise_user_error('translation_overridden', {
                     'name': translation.name,
                     'name': translation.overriding_module,
@@ -319,12 +319,12 @@ class Translation:
         cursor = Transaction().cursor
         table = cls.__table__()
         where = (
-            (table.lang == lang)
-            & (table.type == ttype)
-            & (table.value != '')
-            & (table.value != None)
-            & (table.fuzzy == False)
-            & (table.src == source)
+            (table.lang == lang) &
+            (table.type == ttype) &
+            (table.value != '') &
+            (table.value != None) &
+            (table.fuzzy == False) &
+            (table.src == source)
         )
         if module is not None:
             where &= (table.module == module)
@@ -644,12 +644,12 @@ class TranslationUpdate:
         cursor.execute(*(
             translation.select(
                 *columns,
-                where=(translation.lang == 'en_US')
-                & translation.type.in_(types))
-            - translation.select(
+                where=(translation.lang == 'en_US') &
+                translation.type.in_(types)) -
+            translation.select(
                 *columns,
-                where=(translation.lang == lang)
-                & translation.type.in_(types))
+                where=(translation.lang == lang) &
+                translation.type.in_(types))
         ))
         to_create = []
         for row in cursor.dictfetchall():

--- a/trytond_nereid/user.py
+++ b/trytond_nereid/user.py
@@ -39,7 +39,7 @@ __all__ = ['NereidUser', 'NereidAnonymousUser', 'Permission', 'UserPermission']
 class RegistrationForm(Form):
     "Simple Registration form"
     name = TextField(_('Name'), [validators.DataRequired(), ])
-    email = TextField(_('e-mail'), [validators.DataRequired(), validators.Email()])
+    email = TextField(_('e-mail'), [validators.DataRequired(), validators.Email()])  # noqa
     password = PasswordField(_('New Password'), [
         validators.DataRequired(),
         validators.EqualTo('confirm', message=_('Passwords must match'))])

--- a/trytond_nereid/user.py
+++ b/trytond_nereid/user.py
@@ -38,10 +38,10 @@ __all__ = ['NereidUser', 'NereidAnonymousUser', 'Permission', 'UserPermission']
 
 class RegistrationForm(Form):
     "Simple Registration form"
-    name = TextField(_('Name'), [validators.Required(), ])
-    email = TextField(_('e-mail'), [validators.Required(), validators.Email()])
+    name = TextField(_('Name'), [validators.DataRequired(), ])
+    email = TextField(_('e-mail'), [validators.DataRequired(), validators.Email()])
     password = PasswordField(_('New Password'), [
-        validators.Required(),
+        validators.DataRequired(),
         validators.EqualTo('confirm', message=_('Passwords must match'))])
     confirm = PasswordField(_('Confirm Password'))
 
@@ -59,7 +59,7 @@ class NewPasswordForm(Form):
     Form to set a new password
     """
     password = PasswordField(_('New Password'), [
-        validators.Required(),
+        validators.DataRequired(),
         validators.EqualTo('confirm', message=_('Passwords must match'))])
     confirm = PasswordField(_('Repeat Password'))
 
@@ -68,7 +68,7 @@ class ChangePasswordForm(NewPasswordForm):
     """
     Form to change the password
     """
-    old_password = PasswordField(_('Old Password'), [validators.Required()])
+    old_password = PasswordField(_('Old Password'), [validators.DataRequired()])
 
 
 STATES = {
@@ -79,7 +79,7 @@ STATES = {
 class ProfileForm(Form):
     """User Profile Form"""
     display_name = TextField(
-        'Display Name', [validators.Required(), ],
+        'Display Name', [validators.DataRequired(), ],
         description="Your display name"
     )
     timezone = SelectField(
@@ -88,7 +88,7 @@ class ProfileForm(Form):
         coerce=unicode, description="Your timezone"
     )
     email = TextField(
-        'Email', [validators.Required(), validators.Email()],
+        'Email', [validators.DataRequired(), validators.Email()],
         description="Your Login Email. This Cannot be edited."
     )
 
@@ -96,7 +96,7 @@ class ProfileForm(Form):
 class ResetAccountForm(Form):
     """Reset Account Form"""
     email = TextField(
-        'Email', [validators.Required(), validators.Email()],
+        'Email', [validators.DataRequired(), validators.Email()],
         description="Your Login Email."
     )
 

--- a/trytond_nereid/website.py
+++ b/trytond_nereid/website.py
@@ -29,8 +29,8 @@ __all__ = ['WebSite', 'WebSiteLocale', 'WebsiteCountry',
 
 class LoginForm(Form):
     "Default Login Form"
-    email = TextField(_('e-mail'), [validators.Required(), validators.Email()])
-    password = PasswordField(_('Password'), [validators.Required()])
+    email = TextField(_('e-mail'), [validators.DataRequired(), validators.Email()])
+    password = PasswordField(_('Password'), [validators.DataRequired()])
     remember = BooleanField(_('Remember me'), default=False)
 
 

--- a/trytond_nereid/website.py
+++ b/trytond_nereid/website.py
@@ -29,7 +29,7 @@ __all__ = ['WebSite', 'WebSiteLocale', 'WebsiteCountry',
 
 class LoginForm(Form):
     "Default Login Form"
-    email = TextField(_('e-mail'), [validators.DataRequired(), validators.Email()])
+    email = TextField(_('e-mail'), [validators.DataRequired(), validators.Email()])  # noqa
     password = PasswordField(_('Password'), [validators.DataRequired()])
     remember = BooleanField(_('Remember me'), default=False)
 


### PR DESCRIPTION
`validators.Required()` will soon become deprecated, and Flask-WTF suggests the use of `validators.DataRequired()` instead.