### PR TITLE
Token and Basic auth must use login_user()

### DIFF
--- a/trytond_nereid/tests/test_auth.py
+++ b/trytond_nereid/tests/test_auth.py
@@ -879,6 +879,54 @@ class TestAuth(NereidTestCase):
                 )
                 self.assertEqual(response.data, data['display_name'])
 
+    def test_207_login_basic_authentication_and_active_field(self):
+        """
+        Check if the active field stop the user from logging in.
+        """
+        with Transaction().start(DB_NAME, USER, CONTEXT):
+            self.setup_defaults()
+            app = self.get_app()
+
+            party, = self.party_obj.create([{'name': 'Registered user'}])
+            data = {
+                'party': party,
+                'display_name': 'Registered User',
+                'email': 'email@example.com',
+                'password': 'pass:word',
+                'company': self.company,
+                'active': False,
+            }
+            nereid_user, = self.nereid_user_obj.create([data.copy()])
+
+            with app.test_client() as c:
+                # Send the same request with correct basic authentication
+                basic_auth = base64.b64encode(b'email@example.com:pass:word')
+                headers = {
+                    'Authorization': 'Basic ' + basic_auth.decode(
+                        'utf-8').strip('\r\n')
+                }
+
+                # By default user accounts are active. So login should
+                # work.
+                response = c.get('/me', headers=headers)
+                self.assertEqual(response.status_code, 302)
+
+            nereid_user.active = True
+            nereid_user.save()
+
+            with app.test_client() as c:
+                # Send the same request with correct basic authentication
+                basic_auth = base64.b64encode(b'email@example.com:pass:word')
+                headers = {
+                    'Authorization': 'Basic ' + basic_auth.decode(
+                        'utf-8').strip('\r\n')
+                }
+
+                # By default user accounts are active. So login should
+                # work.
+                response = c.get('/me', headers=headers)
+                self.assertEqual(response.status_code, 200)
+
     def test_210_token_authentication(self):
         """
         Test if token authentication works
@@ -919,12 +967,25 @@ class TestAuth(NereidTestCase):
 
                 # Send the same request with correct token authentication
                 # but using capital 'T' in 'Token'
+                token = nereid_user.get_auth_token()
                 response = c.get(
                     '/me', headers={
-                        'Authorization': 'Token ' + nereid_user.get_auth_token()
+                        'Authorization': 'Token ' + token
                     }
                 )
                 self.assertEqual(response.data, data['display_name'])
+
+            nereid_user.active = False
+            nereid_user.save()
+
+            with app.test_client() as c:
+                # Send the same request with correct token authentication
+                response = c.get(
+                    '/me', headers={
+                        'Authorization': 'token ' + token
+                    }
+                )
+                self.assertEqual(response.status_code, 302)
 
     def test_0400_auth_xhr_wrong(self):
         """

--- a/trytond_nereid/user.py
+++ b/trytond_nereid/user.py
@@ -14,7 +14,8 @@ except ImportError:
 import pytz
 from flask_wtf import Form, RecaptchaField
 from wtforms import TextField, SelectField, validators, PasswordField
-from flask.ext.login import logout_user, AnonymousUserMixin, login_url
+from flask.ext.login import logout_user, AnonymousUserMixin, login_url, \
+    login_user
 from werkzeug import redirect, abort
 
 from nereid import request, url_for, render_template, login_required, flash, \
@@ -706,7 +707,9 @@ class NereidUser(ModelSQL, ModelView):
             except TypeError:
                 pass
             else:
-                return cls.authenticate(*header_val.split(':', 1))
+                user = cls.authenticate(*header_val.split(':', 1))
+                if user and login_user(user):
+                    return user
 
         # TODO: Digest authentication
 
@@ -742,7 +745,9 @@ class NereidUser(ModelSQL, ModelView):
             # should also be invalid.
             return None
 
-        return user
+        if login_user(user):
+            # Login only if the login_user method returns True for the user
+            return user
 
     def get_auth_token(self):
         """
@@ -797,7 +802,7 @@ class NereidUser(ModelSQL, ModelView):
         return bool(self.id)
 
     def is_active(self):
-        return self.active
+        return bool(self.active)
 
     def is_anonymous(self):
         return not self.id


### PR DESCRIPTION
This prevents the logic of validation implemented by Flask-Login
being used to ensure that a user authentication that succeeded
should result in a login.

Without this patch, basic auth and token auth allowed authenticated
users to login successfully even when accounts were disabled.