### PR TITLE
Avoid stale AR being reused

### DIFF
--- a/nereid/application.py
+++ b/nereid/application.py
@@ -432,11 +432,11 @@ class Nereid(Flask):
 
             user, company = website.application_user.id, website.company.id
 
-        language = 'en_US'
-        if req.nereid_website:
-            # If this is a request specific to a website
-            # then take the locale from the website
-            language = req.nereid_locale.language.code
+            language = 'en_US'
+            if website:
+                # If this is a request specific to a website
+                # then take the locale from the website
+                language = website.get_current_locale(req).language.code
 
         # pop locale if specified in the view_args
         req.view_args.pop('locale', None)

--- a/nereid/wrappers.py
+++ b/nereid/wrappers.py
@@ -98,18 +98,8 @@ class Request(RequestBase):
 
     @cached_property
     def nereid_locale(self):
-        """
-        Returns the active record of the current locale.
-        The locale could either be from the URL if the locale was specified
-        in the URL, or the default locale from the website.
-        """
-        if self.view_args and 'locale' in self.view_args:
-            for locale in self.nereid_website.locales:
-                if locale.code == self.view_args['locale']:
-                    return locale
-
-        # Return the default locale
-        return self.nereid_website.default_locale
+        # TODO: Deprecate this and make it a global
+        return self.nereid_website.get_current_locale(self)
 
     @cached_property
     def nereid_language(self):

--- a/trytond_nereid/website.py
+++ b/trytond_nereid/website.py
@@ -396,6 +396,20 @@ class WebSite(ModelSQL, ModelView):
 
         return url_map
 
+    def get_current_locale(self, req):
+        """
+        Returns the active record of the current locale.
+        The locale could either be from the URL if the locale was specified
+        in the URL, or the default locale from the website.
+        """
+        if req.view_args and 'locale' in req.view_args:
+            for locale in self.locales:
+                if locale.code == req.view_args['locale']:
+                    return locale
+
+        # Return the default locale
+        return self.default_locale
+
 
 class WebSiteLocale(ModelSQL, ModelView):
     'Web Site Locale'


### PR DESCRIPTION
The patch that fixed the retry api introduced a case
where the active record tied to the request could have
come from a transaction that is already closed, leaving
an AR that is stale (closed cursor).

This fixes the issue by refactoring the locale lookup to
be a method in website and then calling it in the transaction
where the website is looked up.